### PR TITLE
Add line break to CSS syntax error message

### DIFF
--- a/bin/colorguard
+++ b/bin/colorguard
@@ -45,7 +45,7 @@ function run(css) {
     output = colorguard.inspect(css, options);
   }
   catch (e) {
-    stderr.write('There was an error processing the CSS.\n' + e.toString());
+    stderr.write('There was an error processing the CSS.\n' + e.toString() + '\n');
     return;
   }
 


### PR DESCRIPTION
Before:

```
$ colorguard --file foo.css
There was an error processing the CSS.
Error: missing '}' near line 215:3$ 
```

After:

```
$ colorguard --file foo.css
There was an error processing the CSS.
Error: missing '}' near line 215:3
$ 
```
