### PR TITLE
Support absolute path for --file and --options.

### DIFF
--- a/bin/colorguard
+++ b/bin/colorguard
@@ -13,7 +13,7 @@ var css = [];
 var options;
 
 if (argv.file) {
-  css = fs.readFileSync(path.join(process.cwd(), argv.file), 'utf8');
+  css = fs.readFileSync(path.resolve(process.cwd(), argv.file), 'utf8');
   run(css);
 }
 else {
@@ -31,7 +31,7 @@ else {
 
 function run(css) {
   if (argv.options) {
-    options = JSON.parse(fs.readFileSync(path.join(process.cwd(), argv.options), 'utf8'));
+    options = JSON.parse(fs.readFileSync(path.resolve(process.cwd(), argv.options), 'utf8'));
   }
   else {
     options = {


### PR DESCRIPTION
This patch allows `--file` and `--options` to take absolute file path.

Without it, when given an absolute path, colorguard currently concatenates `cwd` and the absolute path, and throw an error.

```
$ colorguard --file ~/foo.css

fs.js:427
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                 ^
Error: ENOENT, no such file or directory '/Users/shuhei/Users/shuhei/foo.css'
    at Object.fs.openSync (fs.js:427:18)
    at Object.fs.readFileSync (fs.js:284:15)
    at Object.<anonymous> (/Users/shuhei/.nvm/v0.10.28/lib/node_modules/colorguard/bin/colorguard:16:12)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:906:3
```
