### PR TITLE
Initial folder support

### DIFF
--- a/bin/colorguard
+++ b/bin/colorguard
@@ -10,10 +10,20 @@ process.title = 'colorguard';
 
 var colorguard = require('..');
 var css = [];
-var options;
+var options,
+    dirFiles;
 
-if (argv.file) {
-  css = fs.readFileSync(path.resolve(process.cwd(), argv.file), 'utf8');
+if (argv.folder) {
+  dirFiles = getCssFiles(argv.folder);
+  dirFiles.forEach(function(fileName) {
+    var filePath = argv.folder + fileName;
+    css = css.concat(getFileContents(argv.folder + fileName));
+  });
+
+  run(css.join());
+}
+else if (argv.file) {
+  css = getFileContents(argv.file);
   run(css);
 }
 else {
@@ -27,6 +37,17 @@ else {
     css = css.join();
     run(css);
   });
+}
+
+function getCssFiles(dirpath) {
+  var files = fs.readdirSync(path.resolve(process.cwd(), dirpath), 'utf8');
+  return files.filter(function(fileName) {
+    return fileName.split('.')[1] === 'css';
+  });
+}
+
+function getFileContents(dirpath) {
+  return fs.readFileSync(path.resolve(process.cwd(), dirpath), 'utf8');
 }
 
 function run(css) {

--- a/test/fixtures/simple2.css
+++ b/test/fixtures/simple2.css
@@ -1,0 +1,4 @@
+.classname2 {
+  background-image: -webkit-linear-gradient(rgba(0,0,0,1), #020202);
+  color: #000000;
+}


### PR DESCRIPTION
This PR starts to address https://github.com/SlexAxton/css-colorguard/issues/7, a few questions:
- The input currently concatenates all the CSS files together and reports line numbers that aren't useful anymore past the first file). What's the ideal output format in this case? I see two ways of approaching this: 
  - handle each CSS file individually (file name keys to current output blob)
  - handle them all together and add support in the output for mapping line number + file name (`line: [1 (foo.css), 1 (bar.css)]`)
- Recursively look in directory for CSS files or top level of folder?
