### PR TITLE
Bundle only core files in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
   "scripts": {
     "test": "mocha --require should --reporter spec"
   },
-  "files": {
+  "files": [
     "bin",
     "lib",
     "index.js"
-  },
+  ],
   "bin": "./bin/colorguard",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Add files section to package.json to include only required core files when people npm install package.
