### PR TITLE
show usage when called without files in tty

### DIFF
--- a/bin/colorguard
+++ b/bin/colorguard
@@ -1,10 +1,18 @@
 #!/usr/bin/env node
-var argv = require('yargs').argv;
+var yargs = require('yargs');
 var fs = require('fs');
 var path = require('path');
 var stdin = process.stdin;
 var stdout = process.stdout;
 var stderr = process.stderr;
+var argv = yargs.argv;
+
+yargs
+.describe('file', 'A CSS file')
+.describe('threshold', 'Threshold of allowable color difference')
+.describe('options', 'An optional JSON file containing all options (Overrides `--threshold`)')
+.describe('format', 'Output type to full json')
+.usage('Usage: colorguard --file [style.css] ');
 
 process.title = 'colorguard';
 
@@ -19,14 +27,19 @@ if (argv.file) {
 else {
   stdin.setEncoding('utf8');
 
-  stdin.on('data', function(chunk) {
-    css.push(chunk);
-  });
+  if (process.stdin.isTTY) {
+    yargs.showHelp();
+  }
+  else {
+    stdin.on('data', function(chunk) {
+      css.push(chunk);
+    });
 
-  stdin.on('end', function() {
-    css = css.join();
-    run(css);
-  });
+    stdin.on('end', function() {
+      css = css.join();
+      run(css);
+    });
+  }
 }
 
 function run(css) {


### PR DESCRIPTION
currently just calling `colorguard` with no options hangs, becuase we listen for `data` events for piped info.
When `isTTY` is true, we are not being piped, and as a result nothing will ever happen ever. which sucks.

show I added some metadata, and now it looks like this

```
 $ colorguard
 Usage: colorguard --file [style.css]

 Options:
   --file       A CSS file
   --threshold  Threshold of allowable color difference
   --options    An optional JSON file containing all options (Overrides `--threshold`)
   --format     Output type to full json
```
