### PR TITLE
update color name replacement regex

### DIFF
--- a/lib/colorguard.js
+++ b/lib/colorguard.js
@@ -222,7 +222,8 @@ exports.inspect = function(css, options) {
   // First just replace css named colors with their hex equivalents before we parse
   // This'll need to probably be different if we want to output ideal css
   Object.keys(cssColorNames).forEach(function(colorName) {
-    css = css.replace(new RegExp("[^A-Za-z]" + colorName + "[^A-Za-z]", 'ig'), cssColorNames[colorName]);
+
+    css = css.replace(new RegExp("[^A-Za-z: ]*\\b" + colorName + "\\b[^A-Za-z ;]*", 'ig'), cssColorNames[colorName]);
   });
 
   // In this section, we more or less ruin the actual css, but not for our purposes. The following


### PR DESCRIPTION
currently in master, given the following css

```
#crazy{color:black;background-color:purple}
```

`black` and `purple` are matched as `:black;` and `purple}`, which means it gets transformed into

```
#crazy { color#000000background-color#800080
```

which causes rework to vomit

this pours pepto all over rework's tum tum
