### PR TITLE
Weird issue with a css classname that is a css color that follows certai...

### DIFF
--- a/lib/colorguard.js
+++ b/lib/colorguard.js
@@ -203,6 +203,14 @@ function getWhitelistHashKey(pair) {
   return pair[0] + '-' + pair[1];
 }
 
+function convertToLab(colorName) {
+    try {
+        return color.rgb_to_lab(hexToRgb(colorName));
+    } catch (e) {
+        throw new Error('Error converting color '+colorName+' to lab format.');
+    }
+}
+
 exports.inspect = function(css, options) {
   colors = {};
   var options = options || {};
@@ -222,8 +230,7 @@ exports.inspect = function(css, options) {
   // First just replace css named colors with their hex equivalents before we parse
   // This'll need to probably be different if we want to output ideal css
   Object.keys(cssColorNames).forEach(function(colorName) {
-
-    css = css.replace(new RegExp("[^A-Za-z: ]*\\b" + colorName + "\\b[^A-Za-z ;]*", 'ig'), cssColorNames[colorName]);
+    css = css.replace(new RegExp("[^A-Za-z: \\D]*\\b" + colorName + "\\b[^A-Za-z ;\\D]*", 'ig'), cssColorNames[colorName]);
   });
 
   // In this section, we more or less ruin the actual css, but not for our purposes. The following
@@ -271,8 +278,8 @@ exports.inspect = function(css, options) {
     for(var j = i + 1; j < colorLen; ++j) {
       if (options.ignore.indexOf(colorNames[j]) >= 0) continue;
       // Convert each to lab format
-      c1 = color.rgb_to_lab(hexToRgb(colorNames[i]));
-      c2 = color.rgb_to_lab(hexToRgb(colorNames[j]));
+      c1 = convertToLab(colorNames[i]);
+      c2 = convertToLab(colorNames[j]);
 
       // Avoid greater than 100 values
       diffAmount = Math.min(color.diff(c1, c2), 100);

--- a/test/fixtures/simple.css
+++ b/test/fixtures/simple.css
@@ -31,6 +31,16 @@
   behavior: url(#default#VML);
 }
 
+/* weird combo of hex color and className containing a color */
+.classnameWithoutColorName .widget.button-widget {
+    margin: auto 2px;
+    border-color: #b1afb0;
+}
+.grey .widget.button-widget a:link,
+.grey .widget.button-widget a:hover{
+    color: #b1afb0;
+}
+
 @-webkit-keyframes spin {
   /* This comment used to break things */
   0% {

--- a/test/test.js
+++ b/test/test.js
@@ -32,6 +32,6 @@ describe('inspect', function() {
   });
 
   it('should have a normalized total count', function() {
-    colorguard.inspect(css).stats.total.should.equal(5);
+    colorguard.inspect(css).stats.total.should.equal(6);
   });
 });


### PR DESCRIPTION
...n hex colors.

I was having a weird issue where the regex for replacing color names was eating up too much css creating a declaration that was incredibly invalid.  The new regex helps but it still replaces classnames/IDs that match a color name in the css colors array.

Additionally I added error catching to the color -> lab format conversion which would have really helped when identifying this issue.
