### PR TITLE
Replace pipetteur with value-parser and color

### DIFF
--- a/lib/colorguard.js
+++ b/lib/colorguard.js
@@ -1,21 +1,26 @@
 var assign = require('object-assign');
+var Color = require('color');
 var colorDiff = require('color-diff');
 var formatter = require('./formatter');
+var isCssColorHex = require('is-css-color-hex');
+var isCssColorName = require('is-css-color-name');
 var postcss = require('postcss');
-var pipetteur = require('pipetteur');
 var reporter = require('postcss-reporter');
+var valueParser = require('postcss-value-parser');
+
+var FUNC_REPRESENTATION = ['rgb', 'rgba', 'hsl', 'hsla', 'hwb'];
+var NODE_TYPES = ['word', 'function']
 
 function convertToLab (clr) {
   clr = clr.rgb();
-
   try {
     return colorDiff.rgb_to_lab({
-      R: Math.round(clr.red() * 255),
-      G: Math.round(clr.green() * 255),
-      B: Math.round(clr.blue() * 255)
+      R: Math.round(clr.r),
+      G: Math.round(clr.g),
+      B: Math.round(clr.b)
     });
   } catch (e) {
-    throw new Error('Error converting color ' + clr.hex() + ' to lab format.');
+    throw new Error('Error converting color ' + clr.hexString() + ' to lab format.');
   }
 }
 
@@ -57,14 +62,32 @@ var colorguard = postcss.plugin('css-colorguard', function (opts) {
     var colors = {};
 
     css.walkDecls(function (decl) {
-      var matches = pipetteur(decl.value);
-      matches.forEach(function (match) {
-        // FIXME: This discards alpha channel
-        var name = match.color.hex();
-        // Just bail if we want to ignore the color
-        if (opts.ignore.indexOf(name) > -1) {
-          return;
+      valueParser(decl.value).walk(function(node) {
+
+        // Return early if the node isn't a function or word
+        if (NODE_TYPES.indexOf(node.type) === -1) { return; }
+
+        // Return early if a word isn't a valid hex or color name
+        if (node.type === 'word' && !isCssColorHex(node.value) && !isCssColorName(node.value)) { return; }
+
+        // Return early if the function isn't a color representation
+        if (node.type === 'function' && FUNC_REPRESENTATION.indexOf(node.value) === -1) { return; }
+
+        var match = {};
+
+        // Consistent string representation of color
+        if (node.type === 'function') {
+          match.match = valueParser.stringify(node);
+        } else {
+          match.match = node.value;
         }
+
+        match.color = Color(match.match);
+
+        var name = match.color.hexString();
+
+        // Just bail if we want to ignore the color
+        if (opts.ignore.indexOf(name) > -1) { return; }
 
         match.declaration = decl;
 

--- a/package.json
+++ b/package.json
@@ -33,13 +33,16 @@
   "homepage": "https://github.com/SlexAxton/css-colorguard",
   "dependencies": {
     "chalk": "^1.1.1",
+    "color": "^0.11.1",
     "color-diff": "^0.1.3",
+    "is-css-color-hex": "^0.2.0",
+    "is-css-color-name": "^0.1.3",
     "log-symbols": "^1.0.2",
     "object-assign": "^4.0.1",
-    "pipetteur": "^1.0.1",
     "plur": "^2.0.0",
     "postcss": "^5.0.4",
     "postcss-reporter": "^1.2.1",
+    "postcss-value-parser": "^3.3.0",
     "text-table": "^0.2.0",
     "yargs": "^1.2.6"
   },


### PR DESCRIPTION
PoC - do not merge.

Ref: https://github.com/SlexAxton/css-colorguard/issues/36

Swaps out pipetteur for `postcss-value-parser` and `color`.

@SlexAxton @davidtheclark If this seems like a sensible route to go down, then I’ll add some more tests for the other colour representations.