### PR TITLE
How to handle the same colors represented differently?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CSS COLORGUARD CHANGELOG
 
+## Head
+
+- Added `allowEquivalentNotation` option
+
 ## 2016-03-15 - 1.1.1
 
 - Upgraded pipetteur to `2.0.0` (thanks to @davidtheclark)

--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ Pass an array of color pairs to ignore:
 [['#000000', '#010101']]
 ```
 
+##### allowEquivalentNotation
+
+Type: `boolean`
+Default: `false`
+
+By default, colorguard will complain if identical colors are represented with different notations.
+For example, `#000`, `#000000`, `rgba(0, 0, 0, 0), and `black`. If you want to permit these
+equivalent notations, set this option to `true`.
+
 ### `postcss([ colorguard(opts) ])`
 
 CSS Colorguard can be consumed as a PostCSS plugin. See the

--- a/bin/colorguard
+++ b/bin/colorguard
@@ -9,6 +9,7 @@ var assign = require('object-assign');
 yargs
 .describe('file', 'A CSS file')
 .describe('threshold', 'Threshold of allowable color difference')
+.describe('allow-equivalent-notation', 'Allow equivalent notation of the same color, e.g. #000 and #000000')
 .describe('options', 'An optional JSON file containing all options (Overrides `--threshold`)')
 .usage('Usage: colorguard --file [style.css] ');
 
@@ -47,6 +48,7 @@ function run (css) {
     if (argv.threshold) {
       options.threshold = argv.threshold;
     }
+    options.allowEquivalentNotation = argv.allowEquivalentNotation;
   }
   if (argv.file) {
     options = assign({

--- a/lib/colorguard.js
+++ b/lib/colorguard.js
@@ -83,6 +83,12 @@ var colorguard = postcss.plugin('css-colorguard', function (opts) {
           }
           var diffAmount = getDiff(cached[0].color, match.color);
 
+          // If colors are the same (no diff) but had a different representation
+          // (e.g. #888 and #88888), do not complain
+          if (diffAmount === 0) {
+            return;
+          }
+
           var whitelisted = getWhitelistHashKey([color, name]);
           if (diffAmount < opts.threshold && !whitelistHash[whitelisted]) {
             var message = (

--- a/lib/colorguard.js
+++ b/lib/colorguard.js
@@ -83,9 +83,9 @@ var colorguard = postcss.plugin('css-colorguard', function (opts) {
           }
           var diffAmount = getDiff(cached[0].color, match.color);
 
-          // If colors are the same (no diff) but had a different representation
-          // (e.g. #888 and #88888), do not complain
-          if (diffAmount === 0) {
+          // If colors are the same (no diff) but have a different representation
+          // (e.g. #000 and #000000 and black), do not complain
+          if (opts.allowEquivalentNotation && diffAmount === 0) {
             return;
           }
 

--- a/test/test.js
+++ b/test/test.js
@@ -90,6 +90,10 @@ var tests = [{
   warningsColors: [
     { secondColor: '#fff', firstColor: 'white' }
   ]
+}, {
+  message: 'identical but different length hexes',
+  fixture: '.foo { color: #888; } .bar { color: #888888; }',
+  warnings: 0,
 }];
 
 tests.forEach(function (test) {

--- a/test/test.js
+++ b/test/test.js
@@ -91,9 +91,17 @@ var tests = [{
     { secondColor: '#fff', firstColor: 'white' }
   ]
 }, {
-  message: 'identical but different length hexes',
+  message: 'identical but different length hexes with default setting',
+  fixture: '.foo { color: #888; } .bar { color: #888888; }',
+  warnings: 1,
+  warningsColors: [
+    { secondColor: '#888888', firstColor: '#888' }
+  ]
+}, {
+  message: 'identical but different length hexes with `allowEquivalentNotation`',
   fixture: '.foo { color: #888; } .bar { color: #888888; }',
   warnings: 0,
+  options: { allowEquivalentNotation: true }
 }];
 
 tests.forEach(function (test) {


### PR DESCRIPTION
I ran into a situation where the same colors was represented in short and long hex format, `#888` and `#88888`, and css-colorguard complained. Since those are the same color, not with a slight but hardly distinguishable difference, I thought may it wasn't this plugin's place to complain about it. So I wrote this test and added some logic to handle it.

But that made a couple of existing tests fail. The existing tests are relying on the fact that the *same* color represented *two ways* (in these tests, hex and `rgba()`) *should* fail. I don't see this documented, though (am I missing that)?

So I opened this to ask about the thinking here and see if there's a deliberate choice to complain about *equal* colors. If so why, and can we document it? Thanks!