### PR TITLE
Don't parse colors found in urls (+tests)

### DIFF
--- a/lib/colorguard.js
+++ b/lib/colorguard.js
@@ -36,6 +36,8 @@ function getDiff (a, b) {
     return Math.min(colorDiff.diff(convertToLab(a), convertToLab(b)), 100);
 }
 
+var stripUrl = /url\(['|"]?.*?['|"]?\)/;
+
 var colorguard = postcss.plugin('css-colorguard', function (opts) {
   opts = assign({
     ignore: [],
@@ -57,7 +59,8 @@ var colorguard = postcss.plugin('css-colorguard', function (opts) {
     var colors = {};
 
     css.walkDecls(function (decl) {
-      var matches = pipetteur(decl.value);
+      var cleanValue = decl.value.replace(stripUrl, '');
+      var matches = pipetteur(cleanValue);
       matches.forEach(function (match) {
         // FIXME: This discards alpha channel
         var name = match.color.hex();

--- a/test/test.js
+++ b/test/test.js
@@ -79,6 +79,17 @@ var tests = [{
     { secondColor: '#000000', firstColor: 'rgba(0,0,0,1)' },
     { secondColor: '#000000', firstColor: '#020202' }
   ]
+}, {
+  message: 'don\'t fail in urls',
+  fixture: '.classname {\n  background-image: url("image-white.png");\n  color: #fff;\n}',
+  warnings: 0
+}, {
+  message: 'don\'t break backgrounds with urls',
+  fixture: '.classname {\n  background: url(image.png) white;\n  color: #fff;\n}',
+  warnings: 1,
+  warningsColors: [
+    { secondColor: '#fff', firstColor: 'white' }
+  ]
 }];
 
 tests.forEach(function (test) {


### PR DESCRIPTION
Strip out any `url(...)` found in a css declaration's value before processing it with pipetteur. Added tests to ensure this is really fixed and that it doesn't break stuff.

Fixes #39. Also should fix https://github.com/stylelint/stylelint/pull/977 when stylelint update's its deps.