### PR TITLE
Swap chalk for turbocolor.

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var chalk = require('chalk');
+var color = require('turbocolor');
 var logSymbols = require('log-symbols');
 var path = require('path');
 var plur = require('plur');
@@ -26,7 +26,7 @@ module.exports = function (input) {
     return '  ' + logSymbols.success + '  No collisions found.';
   }
 
-  var filename = chalk.underline(logFrom(source)) + '\n';
+  var filename = color.underline(logFrom(source)) + '\n';
 
   return filename + table(messages.map(function (msg) {
     var last = msg.text.lastIndexOf('(');
@@ -34,10 +34,10 @@ module.exports = function (input) {
     var position = msg.text.slice(last, msg.text.length);
     return [
       '',
-      chalk.gray('line ' + msg.node.source.start.line),
-      chalk.gray('col ' + msg.node.source.start.column),
+      color.gray('line ' + msg.node.source.start.line),
+      color.gray('col ' + msg.node.source.start.column),
       warning,
-      chalk.gray(position)
+      color.gray(position)
     ];
   })) + collisions(messages);
 };

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/SlexAxton/css-colorguard",
   "dependencies": {
-    "chalk": "^1.1.1",
+    "turbocolor": "^2.2.0",
     "color-diff": "^0.1.3",
     "log-symbols": "^1.0.2",
     "object-assign": "^4.0.1",


### PR DESCRIPTION
Hi @SlexAxton ! 👋 

This PR basically swaps chalk for [Turbocolor](https://github.com/jorgebucaran/turbocolor). That's all.

It ought to give you a perf boost as turbocolor loads **_>20x_** faster and applies styles **_>18x_** faster than chalk for the same API ([benchmarks](https://github.com/jorgebucaran/turbocolor/tree/master/bench#benchmarks)). Node.js >=v4. No dependencies. 

### Perf

<pre>
# Load Time
chalk: 15.190ms
<b>turbocolor: 0.777ms</b>

# All Colors
chalk × 8,729 ops/sec
<b>turbocolor × 158,383 ops/sec</b>

# Chained Colors
chalk × 1,838 ops/sec
<b>turbocolor × 39,830 ops/sec</b>

# Nested Colors
chalk × 4,049 ops/sec
<b>turbocolor × 59,833 ops/sec</b>
</pre>

### Size

- [chalk@2.4.1](https://bundlephobia.com/result?p=chalk@2.4.1) — 20.2 kB (7.5 kB min+gzip)
- [turbocolor@2.2.0](https://bundlephobia.com/result?p=turbocolor@2.2.0) — 1.1 kB (695 B min+gzip)


Let me know if this is acceptable to you. Cheers!