### PR TITLE
refactor: use colorette

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var color = require('turbocolor');
+var gray = require('colorette').gray;
+var underline = require('colorette').underline;
 var logSymbols = require('log-symbols');
 var path = require('path');
 var plur = require('plur');
@@ -26,7 +27,7 @@ module.exports = function (input) {
     return '  ' + logSymbols.success + '  No collisions found.';
   }
 
-  var filename = color.underline(logFrom(source)) + '\n';
+  var filename = underline(logFrom(source)) + '\n';
 
   return filename + table(messages.map(function (msg) {
     var last = msg.text.lastIndexOf('(');
@@ -34,10 +35,10 @@ module.exports = function (input) {
     var position = msg.text.slice(last, msg.text.length);
     return [
       '',
-      color.gray('line ' + msg.node.source.start.line),
-      color.gray('col ' + msg.node.source.start.column),
+      gray('line ' + msg.node.source.start.line),
+      gray('col ' + msg.node.source.start.column),
       warning,
-      color.gray(position)
+      gray(position)
     ];
   })) + collisions(messages);
 };

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
   },
   "homepage": "https://github.com/SlexAxton/css-colorguard",
   "dependencies": {
-    "turbocolor": "^2.2.0",
     "color-diff": "^0.1.3",
+    "colorette": "1.0.1",
     "log-symbols": "^1.0.2",
     "object-assign": "^4.0.1",
     "pipetteur": "^2.0.0",


### PR DESCRIPTION
This PR swaps turbocolor which has been deprecated for colorette. Sorry for the inconvenience! 🙇 

> The project has been renamed to colorette to reflect a major breaking change and a profound shift of the ethos of the project towards minimalism and simplicity.
>
> The prototype-based chainable API has been removed in favor of a simpler approach based on function composition.

Ref: https://github.com/SlexAxton/css-colorguard/pull/55#issuecomment-417516733.